### PR TITLE
Migrate flake8 pre-commit to GitHub

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.8.4
     hooks:
       - id: flake8


### PR DESCRIPTION
This is making the pre-commit auto-update workflow to fail, notifying me every day in GitHub (no idea why)